### PR TITLE
Fix most visited pages URLs

### DIFF
--- a/vocab.js
+++ b/vocab.js
@@ -238,6 +238,11 @@ function addEventListeners(kanji, hiragana) {
 	});
 }
 
+function getDomainFromUrl(url) {
+    const regex = /^(?:https?:\/\/)?(?:www\.)?([^\/]+)/i;
+    const match = url.match(regex);
+    return match ? match[1] : null;
+}
 
 function constructTopSites(mostVisitedURLs) {
   const mostVisitedDiv = document.getElementById('mostVisited_div');
@@ -245,16 +250,20 @@ function constructTopSites(mostVisitedURLs) {
   const numTopSites = 10;
 
   for (let i = 0; i < numTopSites; i++) {
-    const mostVisitedURL = mostVisitedURLs[i].url.replace("https://", "").replace("http://", "").replace("www.", "");
+    const mostVisitedURL = mostVisitedURLs[i].url;
     let a_link = ul.appendChild(document.createElement('a'));
     a_link.href = mostVisitedURL; 
 
     let li = a_link.appendChild(document.createElement('li'));
     li.className = "link";
     
-    let img = li.appendChild(document.createElement("img"));
-    img.src = "http://www.google.com/s2/favicons?domain=" + mostVisitedURL;
-    img.className = "favicon";
+	const domain = getDomainFromUrl(mostVisitedURL);
+
+	if (domain != null) {
+		let img = li.appendChild(document.createElement("img"));
+		img.src = "http://www.google.com/s2/favicons?domain=" + domain;
+		img.className = "favicon";
+	}
 
 	let a = li.appendChild(document.createElement('a'));
     a.href = mostVisitedURL;


### PR DESCRIPTION
In the latest update, the most visited page buttons are broken. When you click on them, the URL it leads to is relative to the extension's URL.

Those most visited sites are complete links. Most likely what happened was that the https and www parts were stripped out to make it possible to embed the favicon using Google's favicon servers, but the links were accidentally left without the https / www part.

This pull request aims to fix this by holding the stripped version of the URL in a separate variable. The hostname of the domain is extracted using some regex magic. The href remains the full URL.